### PR TITLE
Fix missing <arpa/inet.h>

### DIFF
--- a/scripts/blocknotify.c
+++ b/scripts/blocknotify.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <arpa/inet.h>
 
 /*
 


### PR DESCRIPTION
Had problem compiling blocknotify `gcc blocknotify.c -o blocknotify` 
this will fix compiling problem.

