### PR TITLE
Temporary Memory Leak Fix

### DIFF
--- a/libs/stats.js
+++ b/libs/stats.js
@@ -381,7 +381,8 @@ module.exports = function(logger, portalConfig, poolConfigs){
 				['smembers', ':blocksConfirmed'],
 				['hgetall', ':shares:roundCurrent'],
                 ['hgetall', ':blocksPendingConfirms'],
-                ['zrange', ':payments', -100, -1],
+		 // ISSUE #3 reduce the amount of payments displayed to 3
+                ['zrange', ':payments', -3, -1],
                 ['hgetall', ':shares:timesCurrent']
             ];
 
@@ -449,6 +450,9 @@ module.exports = function(logger, portalConfig, poolConfigs){
                             maxRoundTime: 0,
                             shareCount: 0
                         };
+			
+			// ISSUE #3, comment this out if payments still have too many payouts.
+			var numPayments = Math.max(replies[i + 10].length, 100)
                         for(var j = replies[i + 10].length; j > 0; j--){
                             var jsonObj;
                             try {


### PR DESCRIPTION
Payments contains an amounts array.  For whatever reason, the BTCP mining generates about 300kb per payment (your UI displays 100 payments) equalling around 30mb.  ZNOMP then save this to a giant in memory list.  This is bad.

I've lowered the amount of payments recorded to 3.  I've added comments if you just want to get rid of that feature entirely.

There is a similar issue with workers but that is a fraction of this issue, I'll take a look at it if its a problem.

Note: Turning off live stats doesn't fix this because this function is used to render the pages, everyone someone loads the page, the template rendering calls this global stats fun.

Good luck :)