### PR TITLE
live_stats removed to fix memory leak

### DIFF
--- a/website/pages/stats.html
+++ b/website/pages/stats.html
@@ -318,7 +318,9 @@ legend.append('text')
 
 
 <script>
-	window.statsSource = new EventSource("/api/live_stats");
+  /* This will prevent client to listen live_stats */
+	//window.statsSource = new EventSource("/api/live_stats");
+  /*
     $(function() {
         statsSource.addEventListener('message', function (e) {
             var stats = JSON.parse(e.data);
@@ -337,7 +339,7 @@ legend.append('text')
             }
         });
     });
-
+  */
 	function getReadableNetworkHashRateString(hashrate){
 		hashrate = (hashrate * 1000000);
 		if (hashrate < 1000000)

--- a/website/static/miner_stats.js
+++ b/website/static/miner_stats.js
@@ -53,7 +53,7 @@ function buildChartData(){
 			workerHistoryMax = a.hashrate.length;
 		}
 	}
-	
+
 	var i=0;
     workerHashrateData = [];
     for (var worker in workers){
@@ -213,11 +213,12 @@ $.getJSON('/api/worker_stats?'+_miner, function(data){
 	for (var w in statData.workers) { _workerCount++; }
 	buildChartData();
 	displayCharts();
-	rebuildWorkerDisplay();	
+	rebuildWorkerDisplay();
     updateStats();
 });
 
 // live stat updates
+/*NO OPEN CHANNELS
 statsSource.addEventListener('message', function(e){
 	// TODO, create miner_live_stats...
 	// miner_live_stats will return the same josn except without the worker history
@@ -244,3 +245,4 @@ statsSource.addEventListener('message', function(e){
 		}
 	});
 });
+*/


### PR DESCRIPTION
Live stats removed to avoid memory leak

- Event source removed from stats to prevent client to start listening to live_stats api

I also recommend to disable keep-alive param on the load balancer side.