### PR TITLE
Remove uneeded EventSource initializations

### DIFF
--- a/website/pages/miner_stats.html
+++ b/website/pages/miner_stats.html
@@ -100,6 +100,5 @@
 <script>
 	var _miner = "{{=String(it.stats.address).split(".")[0]}}";
 	var _workerCount = 0;
-	window.statsSource = new EventSource("/api/live_stats");
     document.querySelector('main').appendChild(document.createElement('script')).src = '/static/miner_stats.js';
 </script>

--- a/website/pages/stats.html
+++ b/website/pages/stats.html
@@ -318,7 +318,6 @@ legend.append('text')
 
 
 <script>
-	window.statsSource = new EventSource("/api/live_stats");
     $(function() {
         statsSource.addEventListener('message', function (e) {
             var stats = JSON.parse(e.data);


### PR DESCRIPTION
This PR will remove some extraneous connections to the `/api/live_stats` stream since the `EventSource` is already initialized in [`main.js`](https://github.com/BTCPrivate/z-nomp/blob/23ba3751eae555f6d7d22d1cb076645539b92831/website/static/main.js#L28), no extra connections are required. This should relieve some of the active connections to that stream.

Because of how `hotSwap` works, every time you visit `stats.html` and `miner_stats.html` it'll establish another connection, so visiting those pages multiple times without a refresh can open a bunch of connections without ever closing them causing a memory leak on the front end.

You can verify the reduction of connections by checking out the [`liveStatConnections` object](https://github.com/BTCPrivate/z-nomp/blob/23ba3751eae555f6d7d22d1cb076645539b92831/libs/api.js#L12) while bouncing through these pages (`stats` -> `miner_stats` -> `stats` -> `miner_stats` -> `stats` etc), without this patch, it'll start hanging on to more and more connections at once and potentially just kill the server. With the patch, you'll see it'll stop making extraneous connections per navigation to these pages.

This will relieve some stress on the server and front end clients (partially fixing #3).